### PR TITLE
[Enhancement] Decrease dependence on regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ preg_match($cityZipCodeRegex, $address, $matches);
 saveCityZipCode($matches[1], $matches[2]);
 ```
 
-**Good**:
+**Not bad**:
+
+It's better, but we are still heavily dependent on regex.
+
 ```php
 $address = 'One Infinite Loop, Cupertino 95014';
 $cityZipCodeRegex = '/^[^,\\]+[,\\\s]+(.+?)\s*(\d{5})?$/';
@@ -97,6 +100,17 @@ preg_match($cityZipCodeRegex, $address, $matches);
 
 list(, $city, $zipCode) = $matchers;
 saveCityZipCode($city, $zipCode);
+```
+
+**Good**:
+
+Decrease dependence on regex by naming subpatterns.
+```php
+$address = 'One Infinite Loop, Cupertino 95014';
+$cityZipCodeRegex = '/^[^,\\]+[,\\\s]+(?<city>.+?)\s*(?<zipCode>\d{5})?$/';
+preg_match($cityZipCodeRegex, $address, $matches);
+
+saveCityZipCode($matchers['city'], $matchers['zipCode']);
 ```
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Fix for [Use explanatory variables](https://github.com/jupeter/clean-code-php#use-explanatory-variables).

It will be better use [named subpatterns](http://php.net/manual/en/regexp.reference.subpatterns.php).