### PR TITLE
Drop singleton 

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,38 +525,6 @@ function config()
 }
 ```
 
-**Bad too:**
-
-Singleton is a [anti-pattern](https://en.wikipedia.org/wiki/Singleton_pattern).
-
-```php
-class Configuration
-{
-    private static $instance;
-
-    private function __construct($configuration)
-    {
-        // ...
-    }
-
-    public static function getInstance()
-    {
-        if (self::$instance === null) {
-            self::$instance = new Configuration();
-        }
-
-        return self::$instance;
-    }
-
-    public function get($key)
-    {
-        // ...
-    }
-}
-
-$singleton = Configuration::getInstance();
-```
-
 **Good:**
 
 Create PHP configuration file or something else
@@ -592,6 +560,60 @@ $configuration = new Configuration($configuration);
 ```
 
 And now you must use instance of `Configuration` in your application.
+
+**[⬆ back to top](#table-of-contents)**
+
+### Don't use a Singleton pattern
+Singleton is a [anti-pattern](https://en.wikipedia.org/wiki/Singleton_pattern).
+
+**Bad:**
+
+```php
+class DBConnection
+{
+    private static $instance;
+
+    private function __construct($dsn)
+    {
+        // ...
+    }
+
+    public static function getInstance()
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    // ...
+}
+
+$singleton = DBConnection::getInstance();
+```
+
+**Good:**
+
+```php
+class DBConnection
+{
+    public function __construct(array $dsn)
+    {
+        // ...
+    }
+
+     // ...
+}
+```
+
+Create instance of `DBConnection` class and configure it with [DSN](http://php.net/manual/en/pdo.construct.php#refsect1-pdo.construct-parameters).
+
+```php
+$connection = new DBConnection($dsn);
+```
+
+And now you must use instance of `DBConnection` in your application.
 
 **[⬆ back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -512,35 +512,64 @@ Polluting globals is a bad practice in very languages because you could clash wi
 library and the user of your API would be none-the-wiser until they get an exception in 
 production. Let's think about an example: what if you wanted to have configuration array. 
 You could write global function like `config()`, but it could clash with another library 
-that tried to do the same thing. This is why it
-would be much better to use singleton design pattern and simple set configuration.
+that tried to do the same thing.
 
 **Bad:**
 ```php
-function config() {
+function config()
+{
     return  [
-        'foo': 'bar',
+        'foo' => 'bar',
     ]
 }
 ```
 
 **Good:**
-```php
-class Configuration {
-    private static $instance;
-    private function __construct($configuration) {/* */}
-    public static function getInstance() {
-        if (self::$instance === null) {
-            self::$instance = new Configuration();
-        }
-        return self::$instance;
-    }
-    public function get($key) {/* */}
-    public function getAll() {/* */}
-}
 
-$singleton = Configuration::getInstance();
+Create configuration file
+
+```php
+// config.php
+return [
+    'foo' => 'bar',
+];
 ```
+
+Or a [YAML](https://en.wikipedia.org/wiki/YAML) configuration file
+
+```php
+// config.yml
+configuration:
+    foo: 'bar'
+```
+
+Or something else
+
+```php
+class Configuration
+{
+    private $configuration = [];
+
+    public function __construct(array $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    public function get($key)
+    {
+        return isset($this->configuration[$key]) ? $this->configuration[$key] : null;
+    }
+}
+```
+
+Load configuration from file and create instance of `Configuration` class 
+
+```php
+$configuration = new Configuration($configuration);
+```
+
+And now you must use instance of `Configuration` in your application.
+
 **[⬆ back to top](#table-of-contents)**
 
 ### Encapsulate conditionals

--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ You could write global function like `config()`, but it could clash with another
 that tried to do the same thing.
 
 **Bad:**
+
 ```php
 function config()
 {
@@ -524,9 +525,41 @@ function config()
 }
 ```
 
+**Bad too:**
+
+Singleton is a [anti-pattern](https://en.wikipedia.org/wiki/Singleton_pattern).
+
+```php
+class Configuration
+{
+    private static $instance;
+
+    private function __construct($configuration)
+    {
+        // ...
+    }
+
+    public static function getInstance()
+    {
+        if (self::$instance === null) {
+            self::$instance = new Configuration();
+        }
+
+        return self::$instance;
+    }
+
+    public function get($key)
+    {
+        // ...
+    }
+}
+
+$singleton = Configuration::getInstance();
+```
+
 **Good:**
 
-Create configuration file
+Create PHP configuration file or something else
 
 ```php
 // config.php
@@ -534,16 +567,6 @@ return [
     'foo' => 'bar',
 ];
 ```
-
-Or a [YAML](https://en.wikipedia.org/wiki/YAML) configuration file
-
-```php
-// config.yml
-configuration:
-    foo: 'bar'
-```
-
-Or something else
 
 ```php
 class Configuration


### PR DESCRIPTION
Fix for [Don't write to global functions](https://github.com/jupeter/clean-code-php#dont-write-to-global-functions).

Singleton is a [anti-pattern](https://en.wikipedia.org/wiki/Singleton_pattern).
You change a **global** `config()` function to a **global** instance of `Configuration` class.
This is very, very bad.