### PR TITLE
Encapsulate conditionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ would be much better to use singleton design pattern and simple set configuratio
 ```php
 function config() {
     return  [
-        'foo': 'bar',
+        'foo' => 'bar',
     ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1168,7 +1168,7 @@ class Manager {
   /** @var WorkerInterface $worker **/
   private $worker;
   
-  public void setWorker(WorkerInterface $worker) {
+  public function setWorker(WorkerInterface $worker) {
         $this->worker = $worker;
     }
 

--- a/README.md
+++ b/README.md
@@ -788,7 +788,7 @@ class BankAccount {
 $bankAccount = new BankAccount();
 
 // Buy shoes...
-$bankAccount->withdrawBalance(-$shoesPrice);
+$bankAccount->withdrawBalance($shoesPrice);
 
 // Get balance
 $balance = $bankAccount->getBalance();

--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ function createMenu($title, $body, $buttonText, $cancellable) {
 
 **Good**:
 ```php
-class menuConfig() {
+class MenuConfig
+{
     public $title;
     public $body;
     public $buttonText;

--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ preg_match($cityZipCodeRegex, $address, $matches);
 saveCityZipCode($matches[1], $matches[2]);
 ```
 
-**Good**:
+**Not bad**:
+
+It's better, but we are still heavily dependent on regex.
+
 ```php
 $address = 'One Infinite Loop, Cupertino 95014';
 $cityZipCodeRegex = '/^[^,\\]+[,\\\s]+(.+?)\s*(\d{5})?$/';
@@ -97,6 +100,17 @@ preg_match($cityZipCodeRegex, $address, $matches);
 
 list(, $city, $zipCode) = $matchers;
 saveCityZipCode($city, $zipCode);
+```
+
+**Good**:
+
+Decrease dependence on regex by naming subpatterns.
+```php
+$address = 'One Infinite Loop, Cupertino 95014';
+$cityZipCodeRegex = '/^[^,\\]+[,\\\s]+(?<city>.+?)\s*(?<zipCode>\d{5})?$/';
+preg_match($cityZipCodeRegex, $address, $matches);
+
+saveCityZipCode($matchers['city'], $matchers['zipCode']);
 ```
 **[⬆ back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Explicit is better than implicit.
 ```php
 $l = ['Austin', 'New York', 'San Francisco'];
 
-foreach($i=0; $i<count($l); $i++) {
+for ($i = 0; $i < count($l); $i++) {
     $li = $l[$i];
     oStuff();
     doSomeOtherStuff();
@@ -138,9 +138,7 @@ foreach($i=0; $i<count($l); $i++) {
 ```php
 $locations = ['Austin', 'New York', 'San Francisco'];
 
-foreach($i=0; $i<count($locations); $i++) {
-    $location = $locations[$i];
-    
+foreach ($locations as $location) {
     doStuff();
     doSomeOtherStuff();
     // ...

--- a/README.md
+++ b/README.md
@@ -559,22 +559,21 @@ $singleton = Configuration::getInstance();
 ### Encapsulate conditionals
 
 **Bad:**
+
 ```php
-if ($fsm->state === 'fetching' && is_empty($listNode)) {
+if ($article->state === 'published') {
     // ...
 }
 ```
 
 **Good**:
-```php
-function shouldShowSpinner($fsm, $listNode) {
-    return $fsm->state === 'fetching' && is_empty($listNode);
-}
 
-if (shouldShowSpinner($fsmInstance, $listNodeInstance)) {
-  // ...
+```php
+if ($article->isPublished()) {
+    // ...
 }
 ```
+
 **[⬆ back to top](#table-of-contents)**
 
 ### Avoid negative conditionals

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ $address = 'One Infinite Loop, Cupertino 95014';
 $cityZipCodeRegex = '/^[^,\\]+[,\\\s]+(?<city>.+?)\s*(?<zipCode>\d{5})?$/';
 preg_match($cityZipCodeRegex, $address, $matches);
 
-saveCityZipCode($matchers['city'], $matchers['zipCode']);
+saveCityZipCode($matches['city'], $matches['zipCode']);
 ```
 **[⬆ back to top](#table-of-contents)**
 
@@ -124,7 +124,7 @@ $l = ['Austin', 'New York', 'San Francisco'];
 
 for ($i = 0; $i < count($l); $i++) {
     $li = $l[$i];
-    oStuff();
+    doStuff();
     doSomeOtherStuff();
     // ...
     // ...
@@ -925,7 +925,7 @@ abstract class Adapter {
 
 class AjaxAdapter extends Adapter {
     public function __construct() {
-    parent::__construct();
+        parent::__construct();
         $this->name = 'ajaxAdapter';
     }
 }
@@ -1119,7 +1119,7 @@ class Square extends Shape {
     }
     
     public function getArea() {
-        return $this->length * $this->length;
+        return pow($this->length, 2);
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -1202,7 +1202,7 @@ class Worker implements WorkableInterface, FeedableInterface {
 }
 
 class Robot implements WorkableInterface {
-    public void work() {
+    public function work() {
         // ....working
     }
 }
@@ -1296,11 +1296,11 @@ class Manager {
     /** @var Worker $worker **/
     private $worker;
     
-    public void __construct(WorkerInterface $worker) {
+    public function __construct(WorkerInterface $worker) {
         $this->worker = $worker;
     }
     
-    public void manage() {
+    public function manage() {
         $this->worker->work();
     }
 }


### PR DESCRIPTION
The transfer of two different conditions relating to different entities into one function is bad.

My example better demonstrates the essence of the encapsulation of conditions.
The `isPublished()` method belongs to the entity and entity defines the conditions and encapsulates them in themselves.

We can use the status field as a Value Object and encapsulate the condition in it.