### PR TITLE
Encapsulate conditionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,22 +559,21 @@ $singleton = Configuration::getInstance();
 ### Encapsulate conditionals
 
 **Bad:**
+
 ```php
-if ($fsm->state === 'fetching' && is_empty($listNode)) {
+if ($article->state === 'published') {
     // ...
 }
 ```
 
 **Good**:
-```php
-function shouldShowSpinner($fsm, $listNode) {
-    return $fsm->state === 'fetching' && is_empty($listNode);
-}
 
-if (shouldShowSpinner($fsmInstance, $listNodeInstance)) {
-  // ...
+```php
+if ($article->isPublished()) {
+    // ...
 }
 ```
+
 **[⬆ back to top](#table-of-contents)**
 
 ### Avoid negative conditionals


### PR DESCRIPTION
The transfer of two different conditions relating to different entities into one function is bad.

My example better demonstrates the essence of the encapsulation of conditions.
The `isPublished()` method belongs to the entity and entity defines the conditions and encapsulates them in themselves.

We can use the status field as a Value Object and encapsulate the condition in it.