### PR TITLE
Move out dependencies  in one level abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,31 +307,34 @@ addMonthToDate(1, $date);
 **[⬆ back to top](#table-of-contents)**
 
 ### Functions should only be one level of abstraction
+
 When you have more than one level of abstraction your function is usually
 doing too much. Splitting up functions leads to reusability and easier
 testing.
 
 **Bad:**
+
 ```php
-function parseBetterJSAlternative($code) {
+function parseBetterJSAlternative($code)
+{
     $regexes = [
         // ...
     ];
     
     $statements = split(' ', $code);
     $tokens = [];
-    foreach($regexes as $regex) {
-        foreach($statements as $statement) {
+    foreach ($regexes as $regex) {
+        foreach ($statements as $statement) {
             // ...
         }
     }
     
     $ast = [];
-    foreach($tokens as $token) {
+    foreach ($tokens as $token) {
         // lex...
     }
     
-    foreach($ast as $node) {
+    foreach ($ast as $node) {
         // parse...
     }
 }
@@ -340,39 +343,43 @@ function parseBetterJSAlternative($code) {
 **Good:**
 
 ```php
-function tokenize($code) {
+function tokenize($code)
+{
     $regexes = [
         // ...
     ];
     
     $statements = split(' ', $code);
     $tokens = [];
-    foreach($regexes as $regex) {
-        foreach($statements as $statement) {
+    foreach ($regexes as $regex) {
+        foreach ($statements as $statement) {
             $tokens[] = /* ... */;
-        });
-    });
+        }
+    }
     
     return $tokens;
 }
 
-function lexer($tokens) {
+function lexer($tokens)
+{
     $ast = [];
-    foreach($tokens as $token) {
+    foreach ($tokens as $token) {
         $ast[] = /* ... */;
-    });
+    }
     
     return $ast;
 }
 
-function parseBetterJSAlternative($code) {
+function parseBetterJSAlternative($code)
+{
     $tokens = tokenize($code);
     $ast = lexer($tokens);
-    foreach($ast as $node) {
+    foreach ($ast as $node) {
         // parse...
-    });
+    }
 }
 ```
+
 **[⬆ back to top](#table-of-contents)**
 
 ### Remove duplicate code

--- a/README.md
+++ b/README.md
@@ -340,7 +340,9 @@ function parseBetterJSAlternative($code)
 }
 ```
 
-**Good:**
+**Bad too:**
+
+We have carried out some of the functionality, but the `parseBetterJSAlternative()` function is still very complex and not testable.
 
 ```php
 function tokenize($code)
@@ -379,6 +381,72 @@ function parseBetterJSAlternative($code)
     }
 }
 ```
+
+**Good:**
+
+The best solution is move out the dependencies of `parseBetterJSAlternative()` function.
+
+```php
+class Tokenizer
+{
+    public function tokenize($code)
+    {
+        $regexes = [
+            // ...
+        ];
+
+        $statements = split(' ', $code);
+        $tokens = [];
+        foreach ($regexes as $regex) {
+            foreach ($statements as $statement) {
+                $tokens[] = /* ... */;
+            }
+        }
+
+        return $tokens;
+    }
+}
+```
+
+```php
+class Lexer
+{
+    public function lexify($tokens)
+    {
+        $ast = [];
+        foreach ($tokens as $token) {
+            $ast[] = /* ... */;
+        }
+
+        return $ast;
+    }
+}
+```
+
+```php
+class BetterJSAlternative
+{
+    private $tokenizer;
+    private $lexer;
+
+    public function __construct(Tokenizer $tokenizer, Lexer $lexer)
+    {
+        $this->tokenizer = $tokenizer;
+        $this->lexer = $lexer;
+    }
+
+    public function parse($code)
+    {
+        $tokens = $this->tokenizer->tokenize($code);
+        $ast = $this->lexer->lexify($tokens);
+        foreach ($ast as $node) {
+            // parse...
+        }
+    }
+}
+```
+
+Now we can mock the dependencies and test only the work of method `BetterJSAlternative::parse()`.
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Fix for [Functions should only be one level of abstraction](https://github.com/jupeter/clean-code-php#functions-should-only-be-one-level-of-abstraction).

Your example is still a very complex and not testable.
The best solution is move out the dependencies of `parseBetterJSAlternative()` function.