### PR TITLE
Interface Segregation Principle (ISP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1188,14 +1188,14 @@ all of the settings. Making them optional helps prevent having a "fat interface"
 **Bad:**
 
 ```php
-interface Employe
+interface Employee
 {
     public function work();
 
     public function eat();
 }
 
-class Human implements Employe
+class Human implements Employee
 {
     public function work()
     {
@@ -1208,7 +1208,7 @@ class Human implements Employe
     }
 }
 
-class Robot implements Employe
+class Robot implements Employee
 {
     public function work()
     {
@@ -1221,19 +1221,19 @@ class Robot implements Employe
     }
 }
 
-class Manager implements Employe
+class Manager implements Employee
 {
     private $employees = [];
 
-    public function subdue(Employe $employe)
+    public function subdue(Employee $employee)
     {
-        $this->employees[] = $employe;
+        $this->employees[] = $employee;
     }
 
     public function work()
     {
-        foreach ($this->employees as $employe) {
-            $employe->work();
+        foreach ($this->employees as $employee) {
+            $employee->work();
         }
     }
 
@@ -1257,11 +1257,11 @@ interface Feedable
     public function eat();
 }
 
-interface Employe extends Feedable, Workable
+interface Employee extends Feedable, Workable
 {
 }
 
-class Human implements Employe
+class Human implements Employee
 {
     public function work()
     {
@@ -1283,19 +1283,19 @@ class Robot implements Workable
     }
 }
 
-class Manager implements Employe
+class Manager implements Employee
 {
     private $employees = [];
 
-    public function subdue(Workable $employe)
+    public function subdue(Workable $employee)
     {
-        $this->employees[] = $employe;
+        $this->employees[] = $employee;
     }
 
     public function work()
     {
-        foreach ($this->employees as $employe) {
-            $employe->work();
+        foreach ($this->employees as $employee) {
+            $employee->work();
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1224,7 +1224,7 @@ class Manager
 {
     private $employe;
 
-    public function setWorker(Employe $employe)
+    public function subdue(Employe $employe)
     {
         $this->employe = $employe;
     }
@@ -1266,6 +1266,7 @@ class Human implements Employe
     }
 }
 
+// robot can only work
 class Robot implements Workable
 {
     public function work()
@@ -1278,7 +1279,7 @@ class Manager
 {
     private $employe;
 
-    public function setWorker(Workable $employe)
+    public function subdue(Workable $employe)
     {
       $this->employe = $employe;
     }

--- a/README.md
+++ b/README.md
@@ -1220,28 +1220,6 @@ class Robot implements Employee
         //.... robot can't eating, but it must implement this method
     }
 }
-
-class Manager implements Employee
-{
-    private $employees = [];
-
-    public function subdue(Employee $employee)
-    {
-        $this->employees[] = $employee;
-    }
-
-    public function work()
-    {
-        foreach ($this->employees as $employee) {
-            $employee->work();
-        }
-    }
-
-    public function eat()
-    {
-        // ...... eating in launch break
-    }
-}
 ```
 
 **Good:**
@@ -1282,28 +1260,6 @@ class Robot implements Workable
     public function work()
     {
         // ....working
-    }
-}
-
-class Manager implements Employee
-{
-    private $workers = [];
-
-    public function subdue(Workable $worker)
-    {
-        $this->workers[] = $worker;
-    }
-
-    public function work()
-    {
-        foreach ($this->workers as $worker) {
-            $worker->work();
-        }
-    }
-
-    public function eat()
-    {
-        // ...... eating in launch break
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1191,6 +1191,7 @@ all of the settings. Making them optional helps prevent having a "fat interface"
 interface Employe
 {
     public function work();
+
     public function eat();
 }
 
@@ -1220,20 +1221,25 @@ class Robot implements Employe
     }
 }
 
-class Manager
+class Manager implements Employe
 {
-    private $employees;
+    private $employees = [];
 
     public function subdue(Employe $employe)
     {
         $this->employees[] = $employe;
     }
 
-    public function manage()
+    public function work()
     {
         foreach ($this->employees as $employe) {
             $employe->work();
         }
+    }
+
+    public function eat()
+    {
+        // ...... eating in launch break
     }
 }
 ```
@@ -1277,20 +1283,25 @@ class Robot implements Workable
     }
 }
 
-class Manager
+class Manager implements Employe
 {
-    private $employees;
+    private $employees = [];
 
     public function subdue(Workable $employe)
     {
         $this->employees[] = $employe;
     }
 
-    public function manage()
+    public function work()
     {
         foreach ($this->employees as $employe) {
             $employe->work();
         }
+    }
+
+    public function eat()
+    {
+        // ...... eating in launch break
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1246,6 +1246,8 @@ class Manager implements Employee
 
 **Good:**
 
+Not every worker is an employee, but every employee is an worker.
+
 ```php
 interface Workable
 {

--- a/README.md
+++ b/README.md
@@ -1188,13 +1188,13 @@ all of the settings. Making them optional helps prevent having a "fat interface"
 **Bad:**
 
 ```php
-interface WorkerInterface
+interface Employe
 {
     public function work();
     public function eat();
 }
 
-class Worker implements WorkerInterface
+class Human implements Employe
 {
     public function work()
     {
@@ -1207,7 +1207,7 @@ class Worker implements WorkerInterface
     }
 }
 
-class SuperWorker implements WorkerInterface
+class Robot implements Employe
 {
     public function work()
     {
@@ -1216,22 +1216,22 @@ class SuperWorker implements WorkerInterface
 
     public function eat()
     {
-        //.... eating in launch break
+        //.... robot can't eating, but it must implement this method
     }
 }
 
 class Manager
 {
-    private $worker;
+    private $employe;
 
-    public function setWorker(WorkerInterface $worker)
+    public function setWorker(Employe $employe)
     {
-        $this->worker = $worker;
+        $this->employe = $employe;
     }
 
     public function manage()
     {
-        $this->worker->work();
+        $this->employe->work();
     }
 }
 ```
@@ -1239,21 +1239,21 @@ class Manager
 **Good:**
 
 ```php
-interface WorkerInterface extends FeedableInterface, WorkableInterface
-{
-}
-
-interface WorkableInterface
+interface Workable
 {
     public function work();
 }
 
-interface FeedableInterface
+interface Feedable
 {
     public function eat();
 }
 
-class Worker implements WorkableInterface, FeedableInterface
+interface Employe extends Feedable, Workable
+{
+}
+
+class Human implements Employe
 {
     public function work()
     {
@@ -1266,39 +1266,26 @@ class Worker implements WorkableInterface, FeedableInterface
     }
 }
 
-class Robot implements WorkableInterface
+class Robot implements Workable
 {
     public function work()
     {
         // ....working
-    }
-}
-
-class SuperWorker implements WorkerInterface
-{
-    public function work()
-    {
-        //.... working much more
-    }
-
-    public function eat()
-    {
-        //.... eating in launch break
     }
 }
 
 class Manager
 {
-    private $worker;
+    private $employe;
 
-    public function setWorker(WorkableInterface $w)
+    public function setWorker(Workable $employe)
     {
-      $this->worker = $w;
+      $this->employe = $employe;
     }
 
     public function manage()
     {
-        $this->worker->work();
+        $this->employe->work();
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1176,6 +1176,7 @@ renderLargeRectangles($shapes);
 **[⬆ back to top](#table-of-contents)**
 
 ### Interface Segregation Principle (ISP)
+
 ISP states that "Clients should not be forced to depend upon interfaces that
 they do not use." 
 
@@ -1185,97 +1186,123 @@ huge amounts of options is beneficial, because most of the time they won't need
 all of the settings. Making them optional helps prevent having a "fat interface".
 
 **Bad:**
+
 ```php
-interface WorkerInterface {
+interface WorkerInterface
+{
     public function work();
     public function eat();
 }
 
-class Worker implements WorkerInterface {
-    public function work() {
+class Worker implements WorkerInterface
+{
+    public function work()
+    {
         // ....working
     }
-    public function eat() {
+
+    public function eat()
+    {
         // ...... eating in launch break
     }
 }
 
-class SuperWorker implements WorkerInterface {
-    public function work() {
+class SuperWorker implements WorkerInterface
+{
+    public function work()
+    {
         //.... working much more
     }
 
-    public function eat() {
+    public function eat()
+    {
         //.... eating in launch break
     }
 }
 
-class Manager {
-  /** @var WorkerInterface $worker **/
-  private $worker;
-  
-  public function setWorker(WorkerInterface $worker) {
+class Manager
+{
+    private $worker;
+
+    public function setWorker(WorkerInterface $worker)
+    {
         $this->worker = $worker;
     }
 
-    public function manage() {
+    public function manage()
+    {
         $this->worker->work();
     }
 }
 ```
 
 **Good:**
+
 ```php
-interface WorkerInterface extends FeedableInterface, WorkableInterface {
+interface WorkerInterface extends FeedableInterface, WorkableInterface
+{
 }
 
-interface WorkableInterface {
+interface WorkableInterface
+{
     public function work();
 }
 
-interface FeedableInterface {
+interface FeedableInterface
+{
     public function eat();
 }
 
-class Worker implements WorkableInterface, FeedableInterface {
-    public function work() {
+class Worker implements WorkableInterface, FeedableInterface
+{
+    public function work()
+    {
         // ....working
     }
 
-    public function eat() {
+    public function eat()
+    {
         //.... eating in launch break
     }
 }
 
-class Robot implements WorkableInterface {
-    public function work() {
+class Robot implements WorkableInterface
+{
+    public function work()
+    {
         // ....working
     }
 }
 
-class SuperWorker implements WorkerInterface  {
-    public function work() {
+class SuperWorker implements WorkerInterface
+{
+    public function work()
+    {
         //.... working much more
     }
 
-    public function eat() {
+    public function eat()
+    {
         //.... eating in launch break
     }
 }
 
-class Manager {
-  /** @var $worker WorkableInterface **/
+class Manager
+{
     private $worker;
 
-    public function setWorker(WorkableInterface $w) {
+    public function setWorker(WorkableInterface $w)
+    {
       $this->worker = $w;
     }
 
-    public function manage() {
+    public function manage()
+    {
         $this->worker->work();
     }
 }
 ```
+
 **[⬆ back to top](#table-of-contents)**
 
 ### Dependency Inversion Principle (DIP)

--- a/README.md
+++ b/README.md
@@ -1222,16 +1222,18 @@ class Robot implements Employe
 
 class Manager
 {
-    private $employe;
+    private $employees;
 
     public function subdue(Employe $employe)
     {
-        $this->employe = $employe;
+        $this->employees[] = $employe;
     }
 
     public function manage()
     {
-        $this->employe->work();
+        foreach ($this->employees as $employe) {
+            $employe->work();
+        }
     }
 }
 ```
@@ -1277,16 +1279,18 @@ class Robot implements Workable
 
 class Manager
 {
-    private $employe;
+    private $employees;
 
     public function subdue(Workable $employe)
     {
-      $this->employe = $employe;
+        $this->employees[] = $employe;
     }
 
     public function manage()
     {
-        $this->employe->work();
+        foreach ($this->employees as $employe) {
+            $employe->work();
+        }
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1285,17 +1285,17 @@ class Robot implements Workable
 
 class Manager implements Employee
 {
-    private $employees = [];
+    private $workers = [];
 
-    public function subdue(Workable $employee)
+    public function subdue(Workable $worker)
     {
-        $this->employees[] = $employee;
+        $this->workers[] = $worker;
     }
 
     public function work()
     {
-        foreach ($this->employees as $employee) {
-            $employee->work();
+        foreach ($this->workers as $worker) {
+            $worker->work();
         }
     }
 


### PR DESCRIPTION
Fix for [Interface Segregation Principle (ISP)](https://github.com/jupeter/clean-code-php#interface-segregation-principle-isp).

Changes:

* Correct CS
* Rename `Worker` to `Employee`
* Rename method `Manager::setWorker()` to `Manager::subdue()`
* Manager can manage several workers
* Manager is also an employee
* Work of a manager is to force workers to work

Not every worker is an employee, but every employee is an worker.