### PR TITLE
Fix spelling under `Remove duplicate code`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
      3. [L: Liskov Substitution Principle (LSP)](#liskov-substitution-principle-lsp)
      4. [I: Interface Segregation Principle (ISP)](#interface-segregation-principle-isp)
      5. [D: Dependency Inversion Principle (DIP)](#dependency-inversion-principle-dip)
+  6. [Don’t repeat yourself (DRY)](#dont-repeat-yourself-dry)
 
 ## Introduction
 
@@ -373,103 +374,6 @@ function parseBetterJSAlternative($code) {
     });
 }
 ```
-**[⬆ back to top](#table-of-contents)**
-
-### Remove duplicate code
-Do your absolute best to avoid duplicate code. Duplicate code is bad because 
-it means that there's more than one place to alter something if you need to 
-change some logic.
-
-Imagine if you run a restaurant and you keep track of your inventory: all your 
-tomatoes, onions, garlic, spices, etc. If you have multiple lists that
-you keep this on, then all have to be updated when you serve a dish with
-tomatoes in them. If you only have one list, there's only one place to update!
-
-Oftentimes you have duplicate code because you have two or more slightly
-different things, that share a lot in common, but their differences force you
-to have two or more separate functions that do much of the same things. Removing 
-duplicate code means creating an abstraction that can handle this set of different 
-things with just one function/module/class.
-
-Getting the abstraction right is critical, that's why you should follow the
-SOLID principles laid out in the *Classes* section. Bad abstractions can be
-worse than duplicate code, so be careful! Having said this, if you can make
-a good abstraction, do it! Don't repeat yourself, otherwise you'll find yourself 
-updating multiple places anytime you want to change one thing.
-
-**Bad:**
-
-```php
-function showDeveloperList($developers)
-{
-    foreach ($developers as $developer) {
-        $expectedSalary = $developer->calculateExpectedSalary();
-        $experience = $developer->getExperience();
-        $githubLink = $developer->getGithubLink();
-        $data = [
-            $expectedSalary,
-            $experience,
-            $githubLink
-        ];
-        
-        render($data);
-    }
-}
-
-function showManagerList($managers)
-{
-    foreach ($managers as $manager) {
-        $expectedSalary = $manager->calculateExpectedSalary();
-        $experience = $manager->getExperience();
-        $githubLink = $manager->getGithubLink();
-        $data = [
-            $expectedSalary,
-            $experience,
-            $githubLink
-        ];
-        
-        render($data);
-    }
-}
-```
-
-**Good:**
-
-```php
-function showList($employees)
-{
-    foreach ($employees as $employe) {
-        $expectedSalary = $employe->calculateExpectedSalary();
-        $experience = $employe->getExperience();
-        $githubLink = $employe->getGithubLink();
-        $data = [
-            $expectedSalary,
-            $experience,
-            $githubLink
-        ];
-        
-        render($data);
-    }
-}
-```
-
-**Very good:**
-
-It is better to use a compact version of the code.
-
-```php
-function showList($employees)
-{
-    foreach ($employees as $employe) {
-        render([
-            $employe->calculateExpectedSalary(),
-            $employe->getExperience(),
-            $employe->getGithubLink()
-        ]);
-    }
-}
-```
-
 **[⬆ back to top](#table-of-contents)**
 
 ### Don't use flags as function parameters
@@ -1515,4 +1419,104 @@ class Employee {
     // ...
 }
 ```
+**[⬆ back to top](#table-of-contents)**
+
+## Don’t repeat yourself (DRY)
+
+Try to observe the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle.
+
+Do your absolute best to avoid duplicate code. Duplicate code is bad because 
+it means that there's more than one place to alter something if you need to 
+change some logic.
+
+Imagine if you run a restaurant and you keep track of your inventory: all your 
+tomatoes, onions, garlic, spices, etc. If you have multiple lists that
+you keep this on, then all have to be updated when you serve a dish with
+tomatoes in them. If you only have one list, there's only one place to update!
+
+Oftentimes you have duplicate code because you have two or more slightly
+different things, that share a lot in common, but their differences force you
+to have two or more separate functions that do much of the same things. Removing 
+duplicate code means creating an abstraction that can handle this set of different 
+things with just one function/module/class.
+
+Getting the abstraction right is critical, that's why you should follow the
+SOLID principles laid out in the [Classes](#classes) section. Bad abstractions can be
+worse than duplicate code, so be careful! Having said this, if you can make
+a good abstraction, do it! Don't repeat yourself, otherwise you'll find yourself 
+updating multiple places anytime you want to change one thing.
+
+**Bad:**
+
+```php
+function showDeveloperList($developers)
+{
+    foreach ($developers as $developer) {
+        $expectedSalary = $developer->calculateExpectedSalary();
+        $experience = $developer->getExperience();
+        $githubLink = $developer->getGithubLink();
+        $data = [
+            $expectedSalary,
+            $experience,
+            $githubLink
+        ];
+        
+        render($data);
+    }
+}
+
+function showManagerList($managers)
+{
+    foreach ($managers as $manager) {
+        $expectedSalary = $manager->calculateExpectedSalary();
+        $experience = $manager->getExperience();
+        $githubLink = $manager->getGithubLink();
+        $data = [
+            $expectedSalary,
+            $experience,
+            $githubLink
+        ];
+        
+        render($data);
+    }
+}
+```
+
+**Good:**
+
+```php
+function showList($employees)
+{
+    foreach ($employees as $employe) {
+        $expectedSalary = $employe->calculateExpectedSalary();
+        $experience = $employe->getExperience();
+        $githubLink = $employe->getGithubLink();
+        $data = [
+            $expectedSalary,
+            $experience,
+            $githubLink
+        ];
+        
+        render($data);
+    }
+}
+```
+
+**Very good:**
+
+It is better to use a compact version of the code.
+
+```php
+function showList($employees)
+{
+    foreach ($employees as $employe) {
+        render([
+            $employe->calculateExpectedSalary(),
+            $employe->getExperience(),
+            $employe->getGithubLink()
+        ]);
+    }
+}
+```
+
 **[⬆ back to top](#table-of-contents)**

--- a/README.md
+++ b/README.md
@@ -528,10 +528,10 @@ function showManagerList($managers)
 ```php
 function showList($employees)
 {
-    foreach ($employees as $employe) {
-        $expectedSalary = $employe->calculateExpectedSalary();
-        $experience = $employe->getExperience();
-        $githubLink = $employe->getGithubLink();
+    foreach ($employees as $employee) {
+        $expectedSalary = $employee->calculateExpectedSalary();
+        $experience = $employee->getExperience();
+        $githubLink = $employee->getGithubLink();
         $data = [
             $expectedSalary,
             $experience,
@@ -550,11 +550,11 @@ It is better to use a compact version of the code.
 ```php
 function showList($employees)
 {
-    foreach ($employees as $employe) {
+    foreach ($employees as $employee) {
         render([
-            $employe->calculateExpectedSalary(),
-            $employe->getExperience(),
-            $employe->getGithubLink()
+            $employee->calculateExpectedSalary(),
+            $employee->getExperience(),
+            $employee->getGithubLink()
         ]);
     }
 }

--- a/README.md
+++ b/README.md
@@ -612,6 +612,8 @@ than the vast majority of other programmers.
 $name = 'Ryan McDermott';
 
 function splitIntoFirstAndLastName() {
+    global $name;
+
     $name = preg_split('/ /', $name);
 }
 

--- a/README.md
+++ b/README.md
@@ -1664,8 +1664,8 @@ class Employee {
 class EmployeeTaxData extends Employee {
     private $ssn, $salary;
     
-    public function __construct($ssn, $salary) {
-        parent::__construct();
+    public function __construct($name, $email, $ssn, $salary) {
+        parent::__construct($name, $email);
         $this->ssn = $ssn;
         $this->salary = $salary;
     }

--- a/README.md
+++ b/README.md
@@ -1487,10 +1487,10 @@ function showManagerList($managers)
 ```php
 function showList($employees)
 {
-    foreach ($employees as $employe) {
-        $expectedSalary = $employe->calculateExpectedSalary();
-        $experience = $employe->getExperience();
-        $githubLink = $employe->getGithubLink();
+    foreach ($employees as $employee) {
+        $expectedSalary = $employee->calculateExpectedSalary();
+        $experience = $employee->getExperience();
+        $githubLink = $employee->getGithubLink();
         $data = [
             $expectedSalary,
             $experience,
@@ -1509,11 +1509,11 @@ It is better to use a compact version of the code.
 ```php
 function showList($employees)
 {
-    foreach ($employees as $employe) {
+    foreach ($employees as $employee) {
         render([
-            $employe->calculateExpectedSalary(),
-            $employe->getExperience(),
-            $employe->getGithubLink()
+            $employee->calculateExpectedSalary(),
+            $employee->getExperience(),
+            $employee->getGithubLink()
         ]);
     }
 }


### PR DESCRIPTION
Rename all occurences of word `employe` (missing a second `e` at the end) to `employee`.