### PR TITLE
Different function name used in the example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,7 +842,7 @@ and you use PHP 7+ and you can't use polymorphism but you still feel the need to
 type-check, you should consider
 [type declaration](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration)
 or strict mode. It provides you with static typing on top of standard PHP syntax.
-The problem with manually type-checking is that doing it well requires so much
+The problem with manually type-checking is that doing it will require so much
 extra verbiage that the faux "type-safety" you get doesn't make up for the lost
 readability. Keep your PHP clean, write good tests, and have good code reviews.
 Otherwise, do all of that but with PHP strict type declaration or strict mode.

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ function emailClients($clients) {
 ```php
 function emailClients($clients) {
     $activeClients = activeClients($clients);
-    array_walk($activeClients, 'email');
+    array_walk($activeClients, 'activeClients');
 }
 
 function activeClients($clients) {

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ function emailClients($clients) {
 ```php
 function emailClients($clients) {
     $activeClients = activeClients($clients);
-    array_walk($activeClients, 'activeClients');
+    array_walk($activeClients, 'email');
 }
 
 function activeClients($clients) {


### PR DESCRIPTION
Hey,

There's a different function name used in the `array_walk` function. I've fixed it. Also, fixed a typo.
Please check the same and let me know if there are any issues.

Thanks!