### PR TITLE
Change examples for Use searchable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ Make your names searchable.
 
 ```php
 // What the heck is 448 for?
-$result = serialize($data, 448);
+$result = $serializer->serialize($data, 448);
 ```
 
 **Good:**
 
 ```php
-$json = serialize($data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+$json = $serializer->serialize($data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
 ```
 
 ### Use searchable names (part 2)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ $json = serialize($data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESC
 ```php
 // What the heck is 4 for?
 if ($user->access & 4) {
+    // ...
 }
 ```
 
@@ -95,7 +96,7 @@ class User
     const ACCESS_CREATE = 1 << 1; // 0010
     const ACCESS_EDIT = 1 << 2; // 0100
     const ACCESS_DELETE = 1 << 3; // 1000
-    const ACCESS_ALL = self::ACCESS_READ | self::ACCESS_CREATE | self::ACCESS_EDIT | self::ACCESS_DELETE; // 1111
+    const ACCESS_FULL = self::ACCESS_READ | self::ACCESS_CREATE | self::ACCESS_EDIT | self::ACCESS_DELETE; // 1111
 }
 
 if ($user->access & User::ACCESS_EDIT) {

--- a/README.md
+++ b/README.md
@@ -56,27 +56,25 @@ getUser();
 **[⬆ back to top](#table-of-contents)**
 
 ### Use searchable names
+
 We will read more code than we will ever write. It's important that the code we do write is 
 readable and searchable. By *not* naming variables that end up being meaningful for 
 understanding our program, we hurt our readers.
 Make your names searchable.
 
 **Bad:**
-```php
-// What the heck is 86400 for?
-addExpireAt(86400);
 
+```php
+// What the heck is 448 for?
+$result = serialize($data, 448);
 ```
 
-**Good**:
-```php
-// Declare them as capitalized `const` globals.
-interface DateGlobal {
-    const SECONDS_IN_A_DAY = 86400;
-}
+**Good:**
 
-addExpireAt(DateGlobal::SECONDS_IN_A_DAY);
+```php
+$json = serialize($data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
 ```
+
 **[⬆ back to top](#table-of-contents)**
 
 

--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ if ($user->access & 4) {
 ```php
 class User
 {
-    const ACCESS_NONE = 0; // 0000
-    const ACCESS_READ = 1 << 0; // 0001
-    const ACCESS_CREATE = 1 << 1; // 0010
-    const ACCESS_EDIT = 1 << 2; // 0100
-    const ACCESS_DELETE = 1 << 3; // 1000
-    const ACCESS_FULL = self::ACCESS_READ | self::ACCESS_CREATE | self::ACCESS_EDIT | self::ACCESS_DELETE; // 1111
+    const ACCESS_NONE = 0;
+    const ACCESS_READ = 1;
+    const ACCESS_CREATE = 2;
+    const ACCESS_EDIT = 4;
+    const ACCESS_DELETE = 8;
+    const ACCESS_FULL = self::ACCESS_READ | self::ACCESS_CREATE | self::ACCESS_EDIT | self::ACCESS_DELETE;
 }
 
 if ($user->access & User::ACCESS_EDIT) {

--- a/README.md
+++ b/README.md
@@ -91,15 +91,13 @@ if ($user->access & 4) {
 ```php
 class User
 {
-    const ACCESS_NONE = 0;
     const ACCESS_READ = 1;
     const ACCESS_CREATE = 2;
-    const ACCESS_EDIT = 4;
+    const ACCESS_UPDATE = 4;
     const ACCESS_DELETE = 8;
-    const ACCESS_FULL = self::ACCESS_READ | self::ACCESS_CREATE | self::ACCESS_EDIT | self::ACCESS_DELETE;
 }
 
-if ($user->access & User::ACCESS_EDIT) {
+if ($user->access & User::ACCESS_UPDATE) {
     // do edit ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ getUser();
 ```
 **[⬆ back to top](#table-of-contents)**
 
-### Use searchable names
+### Use searchable names (part 1)
 
 We will read more code than we will ever write. It's important that the code we do write is 
 readable and searchable. By *not* naming variables that end up being meaningful for 
@@ -73,6 +73,34 @@ $result = serialize($data, 448);
 
 ```php
 $json = serialize($data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+```
+
+### Use searchable names (part 2)
+
+**Bad:**
+
+```php
+// What the heck is 4 for?
+if ($user->access & 4) {
+}
+```
+
+**Good:**
+
+```php
+class User
+{
+    const ACCESS_NONE = 0; // 0000
+    const ACCESS_READ = 1 << 0; // 0001
+    const ACCESS_CREATE = 1 << 1; // 0010
+    const ACCESS_EDIT = 1 << 2; // 0100
+    const ACCESS_DELETE = 1 << 3; // 1000
+    const ACCESS_ALL = self::ACCESS_READ | self::ACCESS_CREATE | self::ACCESS_EDIT | self::ACCESS_DELETE; // 1111
+}
+
+if ($user->access & User::ACCESS_EDIT) {
+    // do edit ...
+}
 ```
 
 **[⬆ back to top](#table-of-contents)**


### PR DESCRIPTION
An example with `86400` causes a lot of disputes and not everyone agrees with him #17.

I suggest using a simpler version that will clearly show the advantage of using constants.
I offer at once 2 examples, one is simpler, and another is more complicated.