### PR TITLE
Function split() is DEPRECATED

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ function parseBetterJSAlternative($code)
         // ...
     ];
     
-    $statements = split(' ', $code);
+    $statements = explode(' ', $code);
     $tokens = [];
     foreach ($regexes as $regex) {
         foreach ($statements as $statement) {
@@ -386,7 +386,7 @@ function tokenize($code)
         // ...
     ];
     
-    $statements = split(' ', $code);
+    $statements = explode(' ', $code);
     $tokens = [];
     foreach ($regexes as $regex) {
         foreach ($statements as $statement) {
@@ -430,7 +430,7 @@ class Tokenizer
             // ...
         ];
 
-        $statements = split(' ', $code);
+        $statements = explode(' ', $code);
         $tokens = [];
         foreach ($regexes as $regex) {
             foreach ($statements as $statement) {


### PR DESCRIPTION
Function `split()` was [DEPRECATED](http://php.net/manual/en/function.split.php) in PHP 5.3.0, and REMOVED in PHP 7.0.0.