### PR TITLE
Not use config.php file

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,15 +590,6 @@ function config()
 
 **Good:**
 
-Create PHP configuration file or something else
-
-```php
-// config.php
-return [
-    'foo' => 'bar',
-];
-```
-
 ```php
 class Configuration
 {
@@ -616,10 +607,12 @@ class Configuration
 }
 ```
 
-Load configuration from file and create instance of `Configuration` class 
+Load configuration and create instance of `Configuration` class 
 
 ```php
-$configuration = new Configuration($configuration);
+$configuration = new Configuration([
+    'foo' => 'bar',
+]);
 ```
 
 And now you must use instance of `Configuration` in your application.


### PR DESCRIPTION
Not use `config.php` file in section [Don't write to global functions](https://github.com/jupeter/clean-code-php#dont-write-to-global-functions).

I hope that this example will be clearer. See #96