### PR TITLE
fix example in LSP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1673,6 +1673,9 @@ class Square extends Rectangle
     }
 }
 
+/**
+ * @param Rectangle[] $rectangles
+ */
 function renderLargeRectangles(array $rectangles): void
 {
     foreach ($rectangles as $rectangle) {
@@ -1736,6 +1739,9 @@ class Square extends Shape
     }
 }
 
+/**
+ * @param Rectangle[] $rectangles
+ */
 function renderLargeRectangles(array $rectangles): void
 {
     foreach ($rectangles as $rectangle) {

--- a/README.md
+++ b/README.md
@@ -1673,7 +1673,7 @@ class Square extends Rectangle
     }
 }
 
-function renderLargeRectangles(Rectangle $rectangles): void
+function renderLargeRectangles(array $rectangles): void
 {
     foreach ($rectangles as $rectangle) {
         $rectangle->setWidth(4);
@@ -1736,7 +1736,7 @@ class Square extends Shape
     }
 }
 
-function renderLargeRectangles(Shape $rectangles): void
+function renderLargeRectangles(array $rectangles): void
 {
     foreach ($rectangles as $rectangle) {
         if ($rectangle instanceof Square) {


### PR DESCRIPTION
Fix type error in LSP example. "renderLargeRectangles" expects argument of Rectangle type, but logic for array is used. You can use realization of collection pattern to show type hinting if needed.