### PR TITLE
Announce PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ years of collective experience by the authors of *Clean Code*.
 
 Inspired from [clean-code-javascript](https://github.com/ryanmcdermott/clean-code-javascript)
 
+Although many developers still use PHP 5, most of examples in this article work with PHP 7.1+.
+
 ## Variables
 
 ### Use meaningful and pronounceable variable names


### PR DESCRIPTION
I add  announce of PHP version.
Users and contributors should be know that examples is written for PHP 7.1+.

@php-cpm Thanks for idea of https://github.com/php-cpm/clean-code-php/commit/07bcc2d7f772e3a5873a55e52fac5ba33bc4fa56