### PR TITLE
Fix Php version for void type hinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ function createMicrobrewery($name = null): void
 
 **Good:**
 
-If you support only PHP 7+, then you can use [type hinting](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration) and be sure that the `$breweryName` will not be `NULL`.
+If you support only PHP 7.1+, then you can use [type hinting](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration) and be sure that the `$breweryName` will not be `NULL`.
 
 ```php
 function createMicrobrewery(string $breweryName = 'Hipster Brew Co.'): void

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ function createMicrobrewery($name = null): void
 
 **Good:**
 
-If you support only PHP 7.1+, then you can use [type hinting](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration) and be sure that the `$breweryName` will not be `NULL`.
+ You can use [type hinting](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration) and be sure that the `$breweryName` will not be `NULL`.
 
 ```php
 function createMicrobrewery(string $breweryName = 'Hipster Brew Co.'): void


### PR DESCRIPTION
Void Return Type was implemented in 7.1 not lower

https://wiki.php.net/rfc/void_return_type