### PR TITLE
[ISP] Rename classes to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1810,7 +1810,7 @@ interface Employee
     public function eat(): void;
 }
 
-class Human implements Employee
+class HumanEmployee implements Employee
 {
     public function work(): void
     {
@@ -1823,7 +1823,7 @@ class Human implements Employee
     }
 }
 
-class Robot implements Employee
+class RobotEmployee implements Employee
 {
     public function work(): void
     {
@@ -1856,7 +1856,7 @@ interface Employee extends Feedable, Workable
 {
 }
 
-class Human implements Employee
+class HumanEmployee implements Employee
 {
     public function work(): void
     {
@@ -1870,7 +1870,7 @@ class Human implements Employee
 }
 
 // robot can only work
-class Robot implements Workable
+class RobotEmployee implements Workable
 {
     public function work(): void
     {


### PR DESCRIPTION
Rename the classes to indicate that these are not entities in a global context.
[Some people](https://github.com/jupeter/clean-code-php/issues/147#issuecomment-380036081) have problems with this.

In a global context, an employee is a particular case of a human.
In the context of employees it will be vice versa. Human is a special case of employees.