### PR TITLE
Tests

### DIFF
--- a/.travis-build.php
+++ b/.travis-build.php
@@ -25,14 +25,15 @@ foreach ($readMeFile as $lineNumber => $line) {
         }
         $tableOfContentsStarted = false;
 
-        $chaptersFound[] = sprintf('%s [%s](#%s)',
-            strlen($matches['depth']) === 2
-                ? sprintf('  %s.', ++$manIndex)
-                : '     *'
-            ,
-            $matches['title'],
-            preg_replace(['/ /', '/[^-\w]+/'], ['-', ''], strtolower($matches['title']))
-        );
+        if (strlen($matches['depth']) === 2) {
+            $depth = sprintf('  %s.', ++$manIndex);
+        } else {
+            $depth = sprintf(' %s*', str_repeat('  ', strlen($matches['depth']) - 1));
+        }
+
+        $link = preg_replace(['/ /', '/[^-\w]+/'], ['-', ''], strtolower($matches['title']));
+
+        $chaptersFound[] = sprintf('%s [%s](#%s)', $depth, $matches['title'], $link);
     }
     if ($tableOfContentsStarted === true && isset($line[0])) {
         $currentTableOfContentsChapters[] = $line;

--- a/.travis-build.php
+++ b/.travis-build.php
@@ -31,7 +31,10 @@ foreach ($readMeFile as $lineNumber => $line) {
             $depth = sprintf(' %s*', str_repeat('  ', strlen($matches['depth']) - 1));
         }
 
-        $link = preg_replace(['/ /', '/[^-\w]+/'], ['-', ''], strtolower($matches['title']));
+        $link = $matches['title'];
+        $link = strtolower($link);
+        $link = str_replace(' ', '-', $link);
+        $link = preg_replace('/[^-\w]+/u', '', $link);
 
         $chaptersFound[] = sprintf('%s [%s](#%s)', $depth, $matches['title'], $link);
     }

--- a/.travis-build.php
+++ b/.travis-build.php
@@ -31,6 +31,9 @@ foreach ($readMeFile as $lineNumber => $line) {
             $depth = sprintf(' %s*', str_repeat('  ', strlen($matches['depth']) - 1));
         }
 
+        // ignore links in title
+        $matches['title'] = preg_replace('/\[([^\]]+)\]\((?:[^\)]+)\)/u', '$1', $matches['title']);
+
         $link = $matches['title'];
         $link = strtolower($link);
         $link = str_replace(' ', '-', $link);


### PR DESCRIPTION
This PR fix several problems in tests:
* Impossiable use unicode in link
```diff
-  4. [Функции](#Функции)
-     * [Аргументы функций (в идеале два или меньше)](#Аргументы-функций-в-идеале-два-или-меньше)
+  4. [Функции](#)
+     * [Аргументы функций (в идеале два или меньше)](#------)
```
* Not ignore links in title
```diff
-     * [Use identical comparison](#use-identical-comparison)
+     * [Use [identical comparison](http://php.net/manual/en/language.operators.comparison.php)](#use-identical-comparisonhttpphpnetmanualenlanguageoperatorscomparisonphp)
```
* Allow to use only two depth levels in table of contents