### PR TITLE
Correct example in "Function arguments (2 or fewer ideally)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,10 +443,12 @@ of the time a higher-level object will suffice as an argument.
 **Bad:**
 
 ```php
-function createMenu(string $title, string $body, string $buttonText, bool $cancellable): void
+function createMenu(string $title = '', string $body = '', string $buttonText = '', bool $cancellable = false): void
 {
     // ...
 }
+
+createMenu('', '', '', true);
 ```
 
 **Good:**
@@ -454,22 +456,20 @@ function createMenu(string $title, string $body, string $buttonText, bool $cance
 ```php
 class MenuConfig
 {
-    public $title;
-    public $body;
-    public $buttonText;
+    public $title = '';
+    public $body = '';
+    public $buttonText = '';
     public $cancellable = false;
 }
-
-$config = new MenuConfig();
-$config->title = 'Foo';
-$config->body = 'Bar';
-$config->buttonText = 'Baz';
-$config->cancellable = true;
 
 function createMenu(MenuConfig $config): void
 {
     // ...
 }
+
+$config = new MenuConfig();
+$config->cancellable = true;
+createMenu($config);
 ```
 
 **[⬆ back to top](#table-of-contents)**

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ function createMenu(string $title = '', string $body = '', string $buttonText = 
     // ...
 }
 
-createMenu('', '', '', true);
+createMenu('Foo', '', '', true);
 ```
 
 **Good:**
@@ -468,6 +468,7 @@ function createMenu(MenuConfig $config): void
 }
 
 $config = new MenuConfig();
+$config->title = 'Foo';
 $config->cancellable = true;
 createMenu($config);
 ```


### PR DESCRIPTION
fix #151

@damianopetrungaro what do you think about this change? I think that in this form using the DTO is more obvious.